### PR TITLE
Fix #30 - docker image conflict on restart

### DIFF
--- a/inst/cloudconfig/rstudio.yaml
+++ b/inst/cloudconfig/rstudio.yaml
@@ -26,6 +26,7 @@ write_files:
                                   --name=rstudio \
                                   %s
     ExecStop=/usr/bin/docker stop rstudio
+    ExecStopPost=/usr/bin/docker rm rstudio
 
 runcmd:
 - systemctl daemon-reload


### PR DESCRIPTION
This fixes a conflict in the restart of the service, which should also address issues on the VM restart.